### PR TITLE
Expand Python compatibility to 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ You will use this scaffold to complete various exercises during the tutorial. Th
 
 ## Install
 
+Requires Python 3.8.5 or newer.
+
 ```bash
 python -m venv .venv
 source .venv/bin/activate

--- a/dslabs/sim_network.py
+++ b/dslabs/sim_network.py
@@ -11,7 +11,7 @@ Key ideas:
 """
 
 import random
-from typing import Callable, Dict, Any, List, Tuple
+from typing import Callable, Dict, Any, List, Tuple, Set
 from .sim_scheduler import SimScheduler
 
 Action = List[Tuple[int, Dict[str, Any]]]
@@ -112,7 +112,7 @@ def duplicate(p=0.05):
     return _rule
 
 
-def partition(cut: set[tuple[str, str]]):
+def partition(cut: Set[Tuple[str, str]]):
     """Return a rule that blocks traffic for pairs in `cut`.
 
     The `cut` set contains undirected pairs like (`n1`,`n2`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "dslabs"
 version = "0.1.0"
 description = "Teaching scaffold for distributed systems labs"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.8.5"
 authors = [{name = "Carl Scheffler", email = "scheffler@minerva.edu"}]
 dependencies = []
 


### PR DESCRIPTION
## Summary
- Allow running package on Python >=3.8.5
- Use `typing.Set`/`Tuple` for network partition rules
- Document Python 3.8.5 requirement

## Testing
- `pytest` *(no tests found)*
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c05ba72670833195203915dc2c6196